### PR TITLE
feat: Re-added Instrumentation to ActiveCypher

### DIFF
--- a/lib/active_cypher/bolt/transaction.rb
+++ b/lib/active_cypher/bolt/transaction.rb
@@ -4,6 +4,7 @@ module ActiveCypher
   module Bolt
     # Manages transaction state (BEGIN/COMMIT/ROLLBACK) and runs queries within a transaction.
     class Transaction
+      include Instrumentation
       attr_reader :bookmarks, :metadata
 
       # Initializes a new Transaction instance.
@@ -30,66 +31,68 @@ module ActiveCypher
         # Ensure query is a string
         query_str = query.is_a?(String) ? query : query.to_s
 
-        # Send RUN message
-        run_metadata = {}
-        run_msg = Messaging::Run.new(query_str, parameters, run_metadata)
-        @connection.write_message(run_msg)
+        instrument_query(query_str, parameters, context: 'Transaction#run', metadata: { transaction_id: object_id }) do
+          # Send RUN message
+          run_metadata = {}
+          run_msg = Messaging::Run.new(query_str, parameters, run_metadata)
+          @connection.write_message(run_msg)
 
-        # Read response to RUN
-        response = @connection.read_message
-        qid = -1
-        fields = []
+          # Read response to RUN
+          response = @connection.read_message
+          qid = -1
+          fields = []
 
-        case response
-        when Messaging::Success
-          # RUN succeeded, extract metadata
+          case response
+          when Messaging::Success
+            # RUN succeeded, extract metadata
 
-          qid = response.metadata['qid'] if response.metadata.key?('qid')
-          fields = response.metadata['fields'] if response.metadata.key?('fields')
+            qid = response.metadata['qid'] if response.metadata.key?('qid')
+            fields = response.metadata['fields'] if response.metadata.key?('fields')
 
-          # Send PULL to get all records (-1 = all)
-          pull_metadata = { 'n' => -1 }
-          pull_metadata['qid'] = qid if qid != -1
-          pull_msg = Messaging::Pull.new(pull_metadata)
-          @connection.write_message(pull_msg)
+            # Send PULL to get all records (-1 = all)
+            pull_metadata = { 'n' => -1 }
+            pull_metadata['qid'] = qid if qid != -1
+            pull_msg = Messaging::Pull.new(pull_metadata)
+            @connection.write_message(pull_msg)
 
-          # Process PULL response(s)
-          records = []
-          summary_metadata = {}
+            # Process PULL response(s)
+            records = []
+            summary_metadata = {}
 
-          # Read messages until we get a SUCCESS (or FAILURE)
-          loop do
-            msg = @connection.read_message
-            case msg
-            when Messaging::Record
-              # Store record with raw values - processing will happen in the adapter
-              records << msg.values
-            when Messaging::Success
-              # Final SUCCESS with summary metadata
-              summary_metadata = msg.metadata
-              break # Done processing results
-            when Messaging::Failure
-              connection.reset!
-              # PULL failed - transaction is now failed
-              @state = :failed
-              code = msg.metadata['code']
-              message = msg.metadata['message']
-              raise QueryError, "Query execution failed: #{code} - #{message}"
-            else
-              raise ProtocolError, "Unexpected message type: #{msg.class}"
+            # Read messages until we get a SUCCESS (or FAILURE)
+            loop do
+              msg = @connection.read_message
+              case msg
+              when Messaging::Record
+                # Store record with raw values - processing will happen in the adapter
+                records << msg.values
+              when Messaging::Success
+                # Final SUCCESS with summary metadata
+                summary_metadata = msg.metadata
+                break # Done processing results
+              when Messaging::Failure
+                connection.reset!
+                # PULL failed - transaction is now failed
+                @state = :failed
+                code = msg.metadata['code']
+                message = msg.metadata['message']
+                raise QueryError, "Query execution failed: #{code} - #{message}"
+              else
+                raise ProtocolError, "Unexpected message type: #{msg.class}"
+              end
             end
-          end
 
-          # Create and return Result object
-          Result.new(fields, records, summary_metadata, qid)
-        when Messaging::Failure
-          # RUN failed - transaction is now failed
-          @state = :failed
-          code = response.metadata['code']
-          message = response.metadata['message']
-          raise QueryError, "Query execution failed: #{code} - #{message}"
-        else
-          raise ProtocolError, "Unexpected response to RUN: #{response.class}"
+            # Create and return Result object
+            Result.new(fields, records, summary_metadata, qid)
+          when Messaging::Failure
+            # RUN failed - transaction is now failed
+            @state = :failed
+            code = response.metadata['code']
+            message = response.metadata['message']
+            raise QueryError, "Query execution failed: #{code} - #{message}"
+          else
+            raise ProtocolError, "Unexpected response to RUN: #{response.class}"
+          end
         end
       rescue ConnectionError
         @state = :failed
@@ -102,42 +105,44 @@ module ActiveCypher
       def commit
         raise ConnectionError, "Cannot commit a #{@state} transaction" unless @state == :active
 
-        # Send COMMIT message
-        commit_msg = Messaging::Commit.new
-        @connection.write_message(commit_msg)
+        instrument_transaction(:commit, object_id) do
+          # Send COMMIT message
+          commit_msg = Messaging::Commit.new
+          @connection.write_message(commit_msg)
 
-        # Read response to COMMIT
-        response = @connection.read_message
+          # Read response to COMMIT
+          response = @connection.read_message
 
-        case response
-        when Messaging::Success
-          # COMMIT succeeded
+          case response
+          when Messaging::Success
+            # COMMIT succeeded
 
-          @state = :committed
+            @state = :committed
 
-          # Extract bookmarks if any
-          new_bookmarks = []
-          if response.metadata.key?('bookmark')
-            new_bookmarks = [response.metadata['bookmark']]
-            @bookmarks = new_bookmarks
+            # Extract bookmarks if any
+            new_bookmarks = []
+            if response.metadata.key?('bookmark')
+              new_bookmarks = [response.metadata['bookmark']]
+              @bookmarks = new_bookmarks
+            end
+
+            # Mark transaction as completed in the session
+            @session.complete_transaction(self, new_bookmarks)
+
+            new_bookmarks
+          when Messaging::Failure
+            # COMMIT failed
+            @state = :failed
+            code = response.metadata['code']
+            message = response.metadata['message']
+
+            # Mark transaction as completed in the session
+            @session.complete_transaction(self)
+
+            raise QueryError, "Failed to commit transaction: #{code} - #{message}"
+          else
+            raise ProtocolError, "Unexpected response to COMMIT: #{response.class}"
           end
-
-          # Mark transaction as completed in the session
-          @session.complete_transaction(self, new_bookmarks)
-
-          new_bookmarks
-        when Messaging::Failure
-          # COMMIT failed
-          @state = :failed
-          code = response.metadata['code']
-          message = response.metadata['message']
-
-          # Mark transaction as completed in the session
-          @session.complete_transaction(self)
-
-          raise QueryError, "Failed to commit transaction: #{code} - #{message}"
-        else
-          raise ProtocolError, "Unexpected response to COMMIT: #{response.class}"
         end
       rescue ConnectionError
         @state = :failed
@@ -155,7 +160,7 @@ module ActiveCypher
         # If already committed or rolled back, do nothing
         return if @state == :committed || @state == :rolled_back
 
-        begin
+        instrument_transaction(:rollback, object_id) do
           # Send ROLLBACK message
           rollback_msg = Messaging::Rollback.new
           @connection.write_message(rollback_msg)

--- a/lib/active_cypher/instrumentation.rb
+++ b/lib/active_cypher/instrumentation.rb
@@ -132,7 +132,7 @@ module ActiveCypher
     # @param key [String, Symbol] The key to check
     # @return [Boolean] True if the key contains sensitive information
     def sensitive_key?(key)
-      return true if key.to_s.match?(/password|token|secret|credential|key/i)
+      return true if key.to_s.match?(/\b(password|token|secret|credential|key)\b/i)
 
       # Check against Rails filter parameters if available
       if defined?(Rails) && Rails.application

--- a/lib/active_cypher/instrumentation.rb
+++ b/lib/active_cypher/instrumentation.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require 'active_support/notifications'
+
+module ActiveCypher
+  # Instrumentation for ActiveCypher operations.
+  # Because every database operation needs a stopwatch and an audience.
+  module Instrumentation
+    # ------------------------------------------------------------------
+    # Core instrumentation method
+    # ------------------------------------------------------------------
+
+    # Instruments an operation and publishes an event with timing information.
+    # @param operation [String, Symbol] The operation name (prefixed with 'active_cypher.')
+    # @param payload [Hash] Additional context for the event
+    # @yield The operation to instrument
+    # @return [Object] The result of the block
+    def instrument(operation, payload = {})
+      # Start timing with monotonic clock for accuracy (because wall time is for amateurs)
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      # Run the actual operation
+      result = yield
+
+      # Calculate duration in milliseconds (because counting seconds is so 1990s)
+      duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1_000).round(2)
+
+      # Add duration to payload
+      payload[:duration_ms] = duration_ms
+
+      # Publish event via ActiveSupport::Notifications
+      event_name = operation.to_s.start_with?('active_cypher.') ? operation.to_s : "active_cypher.#{operation}"
+      ActiveSupport::Notifications.instrument(event_name, payload)
+
+      # Also log if we have logging capabilities
+      log_instrumented_event(operation, payload) if respond_to?(:logger)
+
+      # Return the original result
+      result
+    end
+
+    # ------------------------------------------------------------------
+    # Specialized instrumentation methods
+    # ------------------------------------------------------------------
+
+    # Instruments a database query.
+    # @param cypher [String] The Cypher query
+    # @param params [Hash] Query parameters
+    # @param context [String] Additional context (e.g., "Model.find")
+    # @param metadata [Hash] Additional metadata
+    # @yield The query operation
+    # @return [Object] The result of the block
+    def instrument_query(cypher, params = {}, context: 'Query', metadata: {}, &)
+      truncated_cypher = cypher.to_s.gsub(/\s+/, ' ').strip
+      truncated_cypher = "#{truncated_cypher[0...97]}..." if truncated_cypher.length > 100
+
+      payload = metadata.merge(
+        cypher: truncated_cypher,
+        params: sanitize_params(params),
+        context: context
+      )
+
+      instrument('query', payload, &)
+    end
+
+    # Instruments a connection operation.
+    # @param operation [Symbol] The connection operation (:connect, :disconnect, etc)
+    # @param config [Hash] Connection configuration
+    # @param metadata [Hash] Additional metadata
+    # @yield The connection operation
+    # @return [Object] The result of the block
+    def instrument_connection(operation, config = {}, metadata: {}, &)
+      payload = metadata.merge(
+        config: sanitize_config(config)
+      )
+
+      instrument("connection.#{operation}", payload, &)
+    end
+
+    # Instruments a transaction operation.
+    # @param operation [Symbol] The transaction operation (:begin, :commit, :rollback)
+    # @param transaction_id [String, Integer] Transaction identifier (if available)
+    # @param metadata [Hash] Additional metadata
+    # @yield The transaction operation
+    # @return [Object] The result of the block
+    def instrument_transaction(operation, transaction_id = nil, metadata: {}, &)
+      payload = metadata.dup
+      payload[:transaction_id] = transaction_id if transaction_id
+
+      instrument("transaction.#{operation}", payload, &)
+    end
+
+    # ------------------------------------------------------------------
+    # Sanitization methods
+    # ------------------------------------------------------------------
+
+    # Sanitizes query parameters to remove sensitive values.
+    # @param params [Hash, Object] The parameters to sanitize
+    # @return [Hash, Object] Sanitized parameters
+    def sanitize_params(params)
+      return params unless params.is_a?(Hash)
+
+      params.each_with_object({}) do |(key, value), sanitized|
+        sanitized[key] = if sensitive_key?(key)
+                           '[FILTERED]'
+                         elsif value.is_a?(Hash)
+                           sanitize_params(value)
+                         else
+                           value
+                         end
+      end
+    end
+
+    # Sanitizes connection configuration to remove sensitive values.
+    # @param config [Hash] The configuration to sanitize
+    # @return [Hash] Sanitized configuration
+    def sanitize_config(config)
+      return {} unless config.is_a?(Hash)
+
+      config.each_with_object({}) do |(key, value), result|
+        result[key] = if sensitive_key?(key)
+                        '[FILTERED]'
+                      elsif value.is_a?(Hash)
+                        sanitize_config(value)
+                      else
+                        value
+                      end
+      end
+    end
+
+    # Determines if a key contains sensitive information that should be filtered.
+    # @param key [String, Symbol] The key to check
+    # @return [Boolean] True if the key contains sensitive information
+    def sensitive_key?(key)
+      return true if key.to_s.match?(/password|token|secret|credential|key/i)
+
+      # Check against Rails filter parameters if available
+      if defined?(Rails) && Rails.application
+        Rails.application.config.filter_parameters.any? do |pattern|
+          case pattern
+          when Regexp
+            key.to_s =~ pattern
+          when Symbol, String
+            key.to_s == pattern.to_s
+          else
+            false
+          end
+        end
+      else
+        false
+      end
+    end
+
+    private
+
+    # ------------------------------------------------------------------
+    # Logging integration
+    # ------------------------------------------------------------------
+    # Logs an instrumented event if logging is available.
+    # @param operation [String, Symbol] The operation name
+    # @param payload [Hash] The event payload
+    def log_instrumented_event(operation, payload)
+      return unless respond_to?(:log_debug)
+
+      # Format duration if available
+      duration_text = payload[:duration_ms] ? " (#{payload[:duration_ms]} ms)" : ''
+      operation_name = operation.to_s.sub(/^active_cypher\./, '')
+
+      case operation_name
+      when /query/
+        log_debug("QUERY#{duration_text}: #{payload[:cypher]}")
+        log_debug("PARAMS: #{payload[:params].inspect}") if payload[:params]
+      when /connection/
+        op = operation_name.sub(/^connection\./, '')
+        log_debug("CONNECTION #{op.upcase}#{duration_text}")
+      when /transaction/
+        op = operation_name.sub(/^transaction\./, '')
+        tx_id = payload[:transaction_id] ? " (ID: #{payload[:transaction_id]})" : ''
+        log_debug("TRANSACTION #{op.upcase}#{tx_id}#{duration_text}")
+      else
+        # Generic fallback, for when you just don't know how to categorize your problems
+        log_debug("#{operation_name.upcase}#{duration_text}")
+      end
+    end
+  end
+end

--- a/test/test_instrumentation.rb
+++ b/test/test_instrumentation.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TestInstrumentation < ActiveSupport::TestCase
+  class TestInstrumentable
+    include ActiveCypher::Instrumentation
+    include ActiveCypher::Logging
+
+    def test_instrument(payload = {})
+      instrument('test', payload) { :success }
+    end
+
+    def test_query(params = {})
+      instrument_query('MATCH (n) RETURN n', params) { :query_success }
+    end
+
+    def test_connection
+      instrument_connection(:connect, { host: 'localhost', username: 'neo4j', password: 'secret' }) { :connected }
+    end
+
+    def test_transaction
+      instrument_transaction(:commit, 123) { :committed }
+    end
+  end
+
+  def setup
+    @events = []
+    @subscriber = ActiveSupport::Notifications.subscribe(/active_cypher/) do |name, _start, _finish, _id, payload|
+      @events << { name: name, payload: payload }
+    end
+    @instrumentable = TestInstrumentable.new
+  end
+
+  def teardown
+    ActiveSupport::Notifications.unsubscribe(@subscriber) if @subscriber
+  end
+
+  test 'basic instrumentation' do
+    result = @instrumentable.test_instrument(test_key: 'test_value')
+
+    assert_equal :success, result
+    assert_equal 1, @events.size
+
+    event = @events.first
+    assert_equal 'active_cypher.test', event[:name]
+    assert_equal 'test_value', event[:payload][:test_key]
+    assert event[:payload][:duration_ms].is_a?(Numeric)
+  end
+
+  test 'query instrumentation' do
+    result = @instrumentable.test_query(name: 'test')
+
+    assert_equal :query_success, result
+    assert_equal 1, @events.size
+
+    event = @events.first
+    assert_equal 'active_cypher.query', event[:name]
+    assert_equal 'MATCH (n) RETURN n', event[:payload][:cypher]
+    assert_equal({ name: 'test' }, event[:payload][:params])
+    assert event[:payload][:duration_ms].is_a?(Numeric)
+  end
+
+  test 'connection instrumentation' do
+    result = @instrumentable.test_connection
+
+    assert_equal :connected, result
+    assert_equal 1, @events.size
+
+    event = @events.first
+    assert_equal 'active_cypher.connection.connect', event[:name]
+    assert_equal 'localhost', event[:payload][:config][:host]
+    assert_equal 'neo4j', event[:payload][:config][:username]
+    assert_equal '[FILTERED]', event[:payload][:config][:password]
+    assert event[:payload][:duration_ms].is_a?(Numeric)
+  end
+
+  test 'transaction instrumentation' do
+    result = @instrumentable.test_transaction
+
+    assert_equal :committed, result
+    assert_equal 1, @events.size
+
+    event = @events.first
+    assert_equal 'active_cypher.transaction.commit', event[:name]
+    assert_equal 123, event[:payload][:transaction_id]
+    assert event[:payload][:duration_ms].is_a?(Numeric)
+  end
+
+  test 'sensitive data is filtered' do
+    config = {
+      username: 'neo4j',
+      password: 'supersecret',
+      api_key: 'private-key',
+      options: {
+        token: 'auth-token',
+        timeout: 30
+      }
+    }
+
+    sanitized = @instrumentable.send(:sanitize_config, config)
+
+    assert_equal 'neo4j', sanitized[:username]
+    assert_equal '[FILTERED]', sanitized[:password]
+    assert_equal '[FILTERED]', sanitized[:api_key]
+    assert_equal 30, sanitized[:options][:timeout]
+    assert_equal '[FILTERED]', sanitized[:options][:token]
+  end
+end


### PR DESCRIPTION
Instrumentation has been re-added to ActiveCypher so we can finally transcend the plane of guesswork and commune directly with the logs. No more scrying into system behavior through cryptic errors and stack traces—now we have cold, enlightened metrics. A key step on our journey toward inner peace and runtime awareness.

Namaste, but make it observability.