### PR TITLE
fix: Fix generator templates and enforce class collision checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 Gemfile.lock
 .idea
 /test/dummy/log/*
+/test/tmp

--- a/lib/active_cypher/generators/node_generator.rb
+++ b/lib/active_cypher/generators/node_generator.rb
@@ -7,6 +7,7 @@ module ActiveCypher
   module Generators
     class NodeGenerator < Rails::Generators::NamedBase
       source_root File.expand_path('templates', __dir__)
+      check_class_collision
 
       argument :attributes, type: :array,
                             default: [], banner: 'name:type name:type'
@@ -16,8 +17,7 @@ module ActiveCypher
                             default: ''
 
       def create_node_file
-        template 'node.rb.erb',
-                 File.join('app/graph', class_path, "#{file_name}.rb")
+        template 'node.rb.erb', File.join('app/graph', class_path, "#{file_name}.rb")
       end
 
       private

--- a/lib/active_cypher/generators/relationship_generator.rb
+++ b/lib/active_cypher/generators/relationship_generator.rb
@@ -7,6 +7,7 @@ module ActiveCypher
   module Generators
     class RelationshipGenerator < Rails::Generators::NamedBase
       source_root File.expand_path('templates', __dir__)
+      check_class_collision
 
       argument :attributes, type: :array,
                             default: [], banner: 'name:type name:type'
@@ -19,8 +20,7 @@ module ActiveCypher
                            desc: 'Cypher relationship type (defaults to class name)'
 
       def create_relationship_file
-        template 'relationship.rb.erb',
-                 File.join('app/graph', class_path, "#{file_name}.rb")
+        template 'relationship.rb.erb', File.join('app/graph', class_path, "#{file_name}.rb")
       end
 
       private

--- a/lib/active_cypher/generators/templates/node.rb.erb
+++ b/lib/active_cypher/generators/templates/node.rb.erb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
-class <%= class_name %> < ApplicationGraphNode
-  <% labels_list.each do |lbl| %>
-  label :<%= lbl %>
-    <% end %>
 
-    <% attributes.each do |attr| -%>
-    attribute :<%= attr.name %>, :<%= attr.type || "string" %>
-  <% end -%>
+class <%= class_name %> < ApplicationGraphNode
+<% if labels_list.any? -%>
+<% labels_list.each do |lbl| -%>
+  label :<%= lbl %>
+<% end -%>
+<% end -%>
+<% if attributes.any? -%>
+<% attributes.each do |attr| -%>
+  attribute :<%= attr.name %>, :<%= attr.type || "string" %>
+<% end -%>
+<% end -%>
 end

--- a/lib/active_cypher/generators/templates/relationship.rb.erb
+++ b/lib/active_cypher/generators/templates/relationship.rb.erb
@@ -2,10 +2,11 @@
 
 class <%= class_name %> < ApplicationGraphRelationship
   from_class :<%= options[:from] %>
-    to_class   :<%= options[:to]   %>
-    type       :<%= relationship_type %>
-
-    <% attributes.each do |attr| -%>
-    attribute :<%= attr.name %>, :<%= attr.type || "string" %>
-  <% end -%>
+  to_class   :<%= options[:to] %>
+  type       :<%= relationship_type %>
+<% if attributes.any? -%>
+<% attributes.each do |attr| -%>
+  attribute :<%= attr.name %>, :<%= attr.type || "string" %>
+<% end -%>
+<% end -%>
 end

--- a/test/generators/node_generator_test.rb
+++ b/test/generators/node_generator_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rails/generators'
+require 'rails/generators/test_case'
+require 'active_cypher/generators/node_generator'
+
+class NodeGeneratorTest < Rails::Generators::TestCase
+  tests ActiveCypher::Generators::NodeGenerator
+  destination File.expand_path('../tmp/generators', __dir__)
+  setup :prepare_destination
+
+  test 'generator creates a node file' do
+    run_generator ['TestNode']
+    assert_file 'app/graph/test_node.rb', /class TestNode < ApplicationGraphNode/
+  end
+
+  test 'generator creates a node file with attributes' do
+    run_generator ['TestNode', 'name:string', 'age:integer']
+    assert_file 'app/graph/test_node.rb' do |content|
+      assert_match(/attribute :name, :string/, content)
+      assert_match(/attribute :age, :integer/, content)
+    end
+  end
+
+  test 'generator creates a node file with custom labels' do
+    run_generator ['TestNode', '--labels=Custom,Labels']
+    assert_file 'app/graph/test_node.rb' do |content|
+      assert_match(/label :Custom/, content)
+      assert_match(/label :Labels/, content)
+    end
+  end
+
+  test 'generator handles class collision' do
+    # Create a dummy model file
+    FileUtils.mkdir_p(File.join(destination_root, 'app/models'))
+    model_path = File.join(destination_root, 'app/models/existing_model.rb')
+    File.write(model_path, <<~RUBY)
+      # frozen_string_literal: true
+      class ExistingModel < ApplicationRecord
+      end
+    RUBY
+
+    # Run the generator with force overwrite
+    run_generator(['ExistingModel', '--force'])
+
+    # It should generate the file with --force
+    assert_file 'app/graph/existing_model.rb'
+  end
+end

--- a/test/generators/relationship_generator_test.rb
+++ b/test/generators/relationship_generator_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rails/generators'
+require 'rails/generators/test_case'
+require 'active_cypher/generators/relationship_generator'
+
+class RelationshipGeneratorTest < Rails::Generators::TestCase
+  tests ActiveCypher::Generators::RelationshipGenerator
+  destination File.expand_path('../tmp/generators', __dir__)
+  setup :prepare_destination
+
+  test 'generator creates a relationship file' do
+    run_generator ['TestRelationship', '--from=SourceNode', '--to=TargetNode']
+    assert_file 'app/graph/test_relationship.rb', /class TestRelationship < ApplicationGraphRelationship/
+  end
+
+  test 'generator creates a relationship file with attributes' do
+    run_generator ['TestRelationship', 'since:datetime', 'active:boolean', '--from=SourceNode', '--to=TargetNode']
+    assert_file 'app/graph/test_relationship.rb' do |content|
+      assert_match(/attribute :since, :datetime/, content)
+      assert_match(/attribute :active, :boolean/, content)
+    end
+  end
+
+  test 'generator creates a relationship file with custom type' do
+    run_generator ['TestRelationship', '--from=SourceNode', '--to=TargetNode', '--type=CUSTOM_TYPE']
+    assert_file 'app/graph/test_relationship.rb' do |content|
+      assert_match(/type\s+:CUSTOM_TYPE/, content)
+    end
+  end
+
+  test 'generator handles class collision' do
+    # Create a dummy model file
+    FileUtils.mkdir_p(File.join(destination_root, 'app/models'))
+    model_path = File.join(destination_root, 'app/models/existing_relation.rb')
+    File.write(model_path, <<~RUBY)
+      # frozen_string_literal: true
+      class ExistingRelation < ApplicationRecord
+      end
+    RUBY
+
+    # Run the generator with force overwrite
+    run_generator(['ExistingRelation', '--from=SourceNode', '--to=TargetNode', '--force'])
+
+    # It should generate the file with --force
+    assert_file 'app/graph/existing_relation.rb'
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ SimpleCov.start do
 end
 
 require_relative 'dummy/config/environment'
+require 'rails/test_help'
 
 PropCheck::Property.configure do |c|
   c.n_runs = ENV.fetch('PROP_CHECK_RUNS', 50).to_i
@@ -26,4 +27,16 @@ module ActiveCypherTest
   end
 end
 
+# Helper methods for generator tests
+module GeneratorTestHelpers
+  # Run generators while capturing output
+  def quietly(&)
+    silence_stream($stdout, &)
+  end
+end
+
+# Make sure the tmp directory exists for generator tests
+FileUtils.mkdir_p(File.expand_path('tmp', __dir__))
+
 ActiveSupport::TestCase.include ActiveCypherTest::PersistedHelper
+Rails::Generators::TestCase.include GeneratorTestHelpers


### PR DESCRIPTION
- Use Rails' check_class_collision in node and relationship generators to prevent overwriting existing classes