### PR TITLE
fix: allow keyword arguments in Relationship#initialize

### DIFF
--- a/lib/active_cypher/relationship.rb
+++ b/lib/active_cypher/relationship.rb
@@ -271,7 +271,8 @@ module ActiveCypher
       _run(:initialize) do
         super()
 
-        # Merge explicit attrs hash with keyword arguments for attributes
+        # Merge explicit attrs hash with keyword arguments for attributes.
+        # Note: `attribute_kwargs` takes precedence over `attrs` for keys that exist in both.
         combined_attrs = attrs.merge(attribute_kwargs)
         assign_attributes(combined_attrs) if combined_attrs.any?
 

--- a/lib/active_cypher/relationship.rb
+++ b/lib/active_cypher/relationship.rb
@@ -155,14 +155,14 @@ module ActiveCypher
 
       # -- factories -----------------------------------------------
       # Mirrors ActiveRecord.create
-      def create(attrs = {}, from_node:, to_node:)
-        new(attrs, from_node: from_node, to_node: to_node).tap(&:save)
+      def create(attrs = {}, from_node:, to_node:, **attribute_kwargs)
+        new(attrs, from_node: from_node, to_node: to_node, **attribute_kwargs).tap(&:save)
       end
 
       # Bang version of create - raises exception if save fails
       # For when you want your relationship failures to be as dramatic as your breakups
-      def create!(attrs = {}, from_node:, to_node:)
-        relationship = create(attrs, from_node: from_node, to_node: to_node)
+      def create!(attrs = {}, from_node:, to_node:, **attribute_kwargs)
+        relationship = create(attrs, from_node: from_node, to_node: to_node, **attribute_kwargs)
         if relationship.persisted?
           relationship
         else
@@ -267,10 +267,14 @@ module ActiveCypher
     attr_accessor :from_node, :to_node
     attr_reader   :new_record
 
-    def initialize(attrs = {}, from_node: nil, to_node: nil)
+    def initialize(attrs = {}, from_node: nil, to_node: nil, **attribute_kwargs)
       _run(:initialize) do
         super()
-        assign_attributes(attrs) if attrs
+
+        # Merge explicit attrs hash with keyword arguments for attributes
+        combined_attrs = attrs.merge(attribute_kwargs)
+        assign_attributes(combined_attrs) if combined_attrs.any?
+
         @from_node  = from_node
         @to_node    = to_node
         @new_record = true

--- a/test/nodes/find_by_test.rb
+++ b/test/nodes/find_by_test.rb
@@ -8,9 +8,9 @@ class FindByTest < ActiveSupport::TestCase
 
   def setup
     # Clean slate because yesterday's data is so yesterday
-    # Using label-less MATCH to ensure we get everything, even badly labeled nodes
-    PersonNode.connection.execute_cypher('MATCH (n) WHERE labels(n) = ["PersonNode"] OR "PersonNode" IN labels(n) DETACH DELETE n')
-    CompanyNode.connection.execute_cypher('MATCH (n) WHERE labels(n) = ["CompanyNode"] OR "CompanyNode" IN labels(n) DETACH DELETE n')
+    # Use the proper database wipe method to ensure complete cleanup
+    PersonNode.connection.send(:wipe_database, confirm: "yes, really")
+    CompanyNode.connection.send(:wipe_database, confirm: "yes, really")
 
     # Create some test data because an empty database is like a party with no guests
     @alice_memgraph = PersonNode.create(name: 'Alice', age: 30, active: true)

--- a/test/relationships/relationship_basic_test.rb
+++ b/test/relationships/relationship_basic_test.rb
@@ -111,4 +111,75 @@ class RelationshipBasicTest < ActiveSupport::TestCase
     )[0][:count]
     assert_equal 0, count_after, 'Should have no relationships after deletion'
   end
+
+  test 'create relationship with keyword arguments' do
+    # Create nodes
+    alice = PersonNode.create(name: 'Alice', age: 30)
+    chess = HobbyNode.create(name: 'Chess', category: 'board game', skill_level: 'beginner')
+
+    assert alice.persisted?, 'Person should be persisted'
+    assert chess.persisted?, 'Hobby should be persisted'
+
+    # Create relationship using keyword args
+    rel = EnjoysRel.new(
+      from_node: alice,
+      to_node: chess,
+      frequency: 'daily',
+      since: Date.today
+    )
+
+    # Verify attributes were set correctly
+    assert_equal alice, rel.from_node
+    assert_equal chess, rel.to_node
+    assert_equal 'daily', rel.frequency
+    assert_equal Date.today, rel.since
+
+    # Save and verify persistence
+    assert rel.save, 'Relationship should save successfully'
+    assert rel.persisted?, 'Relationship should be persisted'
+
+    # Verify in database
+    PersonNode.connection.id_handler
+    result = PersonNode.connection.execute_cypher(
+      "MATCH (p)-[r:ENJOYS]->(h)
+       WHERE id(p) = #{alice.internal_id} AND id(h) = #{chess.internal_id}
+       RETURN COUNT(r) as count, r.frequency as frequency"
+    )
+    assert_equal 1, result[0][:count], 'Expected one relationship in database'
+    assert_equal 'daily', result[0][:frequency], 'Frequency should match'
+  end
+
+  test 'create relationship with keyword arguments using create method' do
+    # Create nodes
+    bob = PersonNode.create(name: 'Bob', age: 25)
+    poker = HobbyNode.create(name: 'Poker', category: 'card game', skill_level: 'expert')
+
+    assert bob.persisted?, 'Person should be persisted'
+    assert poker.persisted?, 'Hobby should be persisted'
+
+    # Create relationship using create method with keyword arguments
+    rel = EnjoysRel.create(
+      from_node: bob,
+      to_node: poker,
+      frequency: 'weekly',
+      since: Date.today - 30
+    )
+
+    # Verify attributes were set correctly and it's persisted
+    assert rel.persisted?, 'Relationship should be persisted immediately'
+    assert_equal bob, rel.from_node
+    assert_equal poker, rel.to_node
+    assert_equal 'weekly', rel.frequency
+    assert_equal Date.today - 30, rel.since
+
+    # Verify in database
+    PersonNode.connection.id_handler
+    result = PersonNode.connection.execute_cypher(
+      "MATCH (p)-[r:ENJOYS]->(h)
+       WHERE id(p) = #{bob.internal_id} AND id(h) = #{poker.internal_id}
+       RETURN COUNT(r) as count, r.frequency as frequency"
+    )
+    assert_equal 1, result[0][:count], 'Expected one relationship in database'
+    assert_equal 'weekly', result[0][:frequency], 'Frequency should match'
+  end
 end

--- a/test/relationships/relationship_basic_test.rb
+++ b/test/relationships/relationship_basic_test.rb
@@ -27,7 +27,6 @@ class RelationshipBasicTest < ActiveSupport::TestCase
     assert_equal chess.internal_id, rel.to_node.internal_id
 
     # Verify in database
-    PersonNode.connection.id_handler
     result = PersonNode.connection.execute_cypher(
       "MATCH (p)-[r:ENJOYS]->(h)
        WHERE id(p) = #{alice.internal_id} AND id(h) = #{chess.internal_id}


### PR DESCRIPTION
Enable ActiveRecord-style attribute initialization for relationship models