### PR TITLE
fix: handle wrong env

### DIFF
--- a/lib/active_cypher/cypher_config.rb
+++ b/lib/active_cypher/cypher_config.rb
@@ -34,7 +34,7 @@ module ActiveCypher
       merged =
         if defined?(Rails::Application)
           # Leverage the very method you pasted:
-          Rails.application.config_for(file, env: env).deep_dup
+          Rails.application.config_for(file, env: env)&.deep_dup || {}
         else
           # Stand‑alone Ruby script: replicate the merge rules.
           raw     = ActiveSupport::ConfigurationFile.parse(file).deep_symbolize_keys


### PR DESCRIPTION
Now when someone uses bin/rails console -e staging with a non-existent environment, instead of crashing with NoMethodError: undefined method 'with_indifferent_access' for nil, it gracefully handles the nil return and provides a proper error message about the missing connection configuration.