### PR TITLE
chore: add Rails 8.1.beta1 CI testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        rails: ['8.0.2', '8.1.0.beta1']
+
+    env:
+      RAILS_VERSION: ${{ matrix.rails }}
+
     services:
       neo4j:
         image: neo4j:latest # Neo4j 2025‑LTS is the current latest tag

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,8 @@ gemspec
 
 gem 'rake', '~> 13.0'
 
-gem 'railties'
+rails_version = ENV['RAILS_VERSION'] || '8.0.2'
+gem 'railties', "~> #{rails_version}"
 
 gem 'minitest', '~> 5.0'
 


### PR DESCRIPTION
Add CI testing for Rails 8.1.0.beta1 alongside Rails 8.0.2 to ensure compatibility with upcoming Rails version.