### PR TITLE
FIX - Handle UUID for neo4j adapter

### DIFF
--- a/lib/active_cypher/connection_adapters/neo4j_adapter.rb
+++ b/lib/active_cypher/connection_adapters/neo4j_adapter.rb
@@ -40,7 +40,8 @@ module ActiveCypher
 
       # Helper methods for Cypher query generation with IDs
       def self.with_direct_id(id)
-        "elementId(r) = #{id}"
+        # Quote the element ID to handle special characters in Neo4j element IDs
+        "elementId(r) = '#{id}'"
       end
 
       def self.with_param_id
@@ -48,7 +49,8 @@ module ActiveCypher
       end
 
       def self.with_direct_node_ids(a_id, b_id)
-        "elementId(p) = #{a_id} AND elementId(h) = #{b_id}"
+        # Quote the element IDs to handle special characters like colons in UUID-based IDs
+        "elementId(p) = '#{a_id}' AND elementId(h) = '#{b_id}'"
       end
 
       def self.with_param_node_ids

--- a/test/neo4j_uuid_element_id_test.rb
+++ b/test/neo4j_uuid_element_id_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'minitest/autorun'
+
+class Neo4jUuidElementIdTest < Minitest::Test
+  def test_with_direct_id_quotes_uuid_element_ids
+    adapter = ActiveCypher::ConnectionAdapters::Neo4jAdapter
+    uuid_element_id = "4:44c8c9cb-f37c-4132-b230-b42995cbd140:18"
+
+    result = adapter.with_direct_id(uuid_element_id)
+    expected = "elementId(r) = '4:44c8c9cb-f37c-4132-b230-b42995cbd140:18'"
+
+    assert_equal expected, result, "Should properly quote UUID-based element IDs"
+  end
+
+  def test_with_direct_node_ids_quotes_uuid_element_ids
+    adapter = ActiveCypher::ConnectionAdapters::Neo4jAdapter
+    from_id = "4:44c8c9cb-f37c-4132-b230-b42995cbd140:18"
+    to_id = "4:44c8c9cb-f37c-4132-b230-b42995cbd140:19"
+
+    result = adapter.with_direct_node_ids(from_id, to_id)
+    expected = "elementId(p) = '4:44c8c9cb-f37c-4132-b230-b42995cbd140:18' AND elementId(h) = '4:44c8c9cb-f37c-4132-b230-b42995cbd140:19'"
+
+    assert_equal expected, result, "Should properly quote both UUID-based element IDs"
+  end
+
+  def test_node_id_equals_value_quotes_uuid_element_ids
+    adapter = ActiveCypher::ConnectionAdapters::Neo4jAdapter
+    uuid_element_id = "4:44c8c9cb-f37c-4132-b230-b42995cbd140:18"
+
+    result = adapter.node_id_equals_value("n", uuid_element_id)
+    expected = "elementId(n) = '4:44c8c9cb-f37c-4132-b230-b42995cbd140:18'"
+
+    assert_equal expected, result, "Should properly quote UUID-based element IDs"
+  end
+
+  def test_relationship_create_query_with_uuid_element_ids
+    # Mock nodes with UUID element IDs
+    from_node = Minitest::Mock.new
+    from_node.expect :persisted?, true
+    from_node.expect :internal_id, "4:44c8c9cb-f37c-4132-b230-b42995cbd140:18"
+
+    to_node = Minitest::Mock.new
+    to_node.expect :persisted?, true
+    to_node.expect :internal_id, "4:44c8c9cb-f37c-4132-b230-b42995cbd140:19"
+
+    adapter = ActiveCypher::ConnectionAdapters::Neo4jAdapter
+
+    # Test the query generation
+    id_clause = adapter.with_direct_node_ids(from_node.internal_id, to_node.internal_id)
+    query = "MATCH (p), (h) WHERE #{id_clause}"
+
+    expected = "MATCH (p), (h) WHERE elementId(p) = '4:44c8c9cb-f37c-4132-b230-b42995cbd140:18' AND elementId(h) = '4:44c8c9cb-f37c-4132-b230-b42995cbd140:19'"
+
+    assert_equal expected, query, "Generated query should have properly quoted UUID element IDs"
+
+    # Verify the query doesn't have unquoted colons that would cause parsing errors
+    refute_match(/elementId\([^)]+\) = 4:/, query, "Element IDs should be quoted to prevent parsing errors")
+  end
+end


### PR DESCRIPTION
# Fix Summary

 The bug was caused by Neo4j element IDs containing special characters (specifically colons in UUID-based element
  IDs like `4:44c8c9cb-f37c-4132-b230-b42995cbd140:18`) being directly embedded into Cypher queries without proper
  quoting.

  ## Changes made:

  1. Neo4jAdapter (lib/active_cypher/connection_adapters/neo4j_adapter.rb:42-52):
    - Updated with_direct_id method to quote element IDs: "elementId(r) = '#{id}'"
    - Updated with_direct_node_ids method to quote both element IDs: "elementId(p) = '#{a_id}' AND elementId(h) = '#{b_id}'"
  2. Test Coverage: Added test/neo4j_uuid_element_id_test.rb with comprehensive tests to verify UUID-based element IDs are properly quoted.

  The fix ensures that element IDs with special characters are properly quoted in Cypher queries, preventing parsing
  errors when Neo4j uses UUID-based element IDs.