### PR TITLE
default to :primary for connects_to mappings

### DIFF
--- a/lib/active_cypher/base.rb
+++ b/lib/active_cypher/base.rb
@@ -13,7 +13,7 @@ module ActiveCypher
   class Base
     # @!attribute [rw] connects_to_mappings
     #   @return [Hash] Because every base class needs a mapping it will never use directly.
-    class_attribute :connects_to_mappings, default: {}
+    class_attribute :connects_to_mappings, default: { reading: :primary, writing: :primary }
 
     # Rails/ActiveModel foundations
     include Logging


### PR DESCRIPTION
According to the first example under Examples:Connection Configuration, ActiveCypher::Base is supposed to default to :primary for connects_to. This makes it do so. 

This isn't an issue for access from models if you define connects_to in ApplicationGraphNode. It is a problem if you try to run a migration, since ActiveCypher::Migrator uses ActiveCypher::Base. I thought it made more sense to do it this way rather than changing ActiveCypher::Migrator to use ApplicationGraphNode, so behavior would be consistent with the example.