### PR TITLE
fix: repair broken has_one/belongs_to/through associations

### DIFF
--- a/lib/active_cypher/associations.rb
+++ b/lib/active_cypher/associations.rb
@@ -13,6 +13,68 @@ module ActiveCypher
       class_attribute :_reflections, instance_writer: false, default: {}
     end
 
+    # Map a logical association direction to a Cyrel relationship direction.
+    # @param direction [:in, :out, :both]
+    # @return [Symbol] the corresponding Cyrel::Direction value
+    def self.cyrel_direction(direction)
+      case direction
+      when :out then Cyrel::Direction::OUT
+      when :in then Cyrel::Direction::IN
+      when :both then Cyrel::Direction::BOTH
+      else raise AssociationError, "Invalid direction: #{direction}"
+      end
+    end
+
+    # A labelled node pattern pinned to a model class.
+    # @param model_class [Class] the node model class
+    # @param alias_name [Symbol] the pattern alias
+    # @return [Cyrel::Pattern::Node]
+    def self.node_pattern(model_class, alias_name)
+      Cyrel::Pattern::Node.new(alias_name, labels: model_class.label_name)
+    end
+
+    # Build a (start)-[rel]->(end) path between two node patterns.
+    # @param start_node [Cyrel::Pattern::Node] the "from" node pattern
+    # @param end_node [Cyrel::Pattern::Node] the "to" node pattern
+    # @param direction [:in, :out, :both] direction relative to start_node
+    # @param rel_type [String, Symbol] the relationship type
+    # @param rel_alias [Symbol, nil] optional alias for the relationship
+    # @return [Cyrel::Pattern::Path]
+    def self.relationship_path(start_node, end_node, direction, rel_type, rel_alias: nil)
+      rel = Cyrel::Pattern::Relationship.new(alias_name: rel_alias, types: rel_type,
+                                             direction: cyrel_direction(direction))
+      Cyrel::Pattern::Path.new([start_node, rel, end_node])
+    end
+
+    # Build a query matching two nodes pinned by their internal ids, ready to
+    # chain a further .match/.create/.delete_ onto. Cyrel orders clauses
+    # canonically, so the trailing operation may be appended in any order.
+    # @param start_node the model instance at the "from" end
+    # @param start_alias [Symbol] alias for the start node
+    # @param end_node the model instance at the "to" end
+    # @param end_alias [Symbol] alias for the end node
+    # @return [Cyrel::Query]
+    def self.match_endpoints(start_node, start_alias, end_node, end_alias)
+      Cyrel::Query.new
+                  .match(node_pattern(start_node.class, start_alias))
+                  .match(node_pattern(end_node.class, end_alias))
+                  .where(Cyrel.node_id(start_alias).eq(start_node.internal_id))
+                  .where(Cyrel.node_id(end_alias).eq(end_node.internal_id))
+    end
+
+    # Order a pair of endpoints by association direction.
+    # @param receiver the model instance owning the association
+    # @param other the associated model instance
+    # @param direction [:in, :out, :both] direction relative to the receiver
+    # @return [Array] [start_node, end_node]
+    def self.ordered_endpoints(receiver, other, direction)
+      case direction
+      when :out, :both then [receiver, other]
+      when :in then [other, receiver]
+      else raise ArgumentError, "Direction '#{direction}' not supported for this operation"
+      end
+    end
+
     class_methods do
       # Defines a one-to-many association.
       #
@@ -171,25 +233,20 @@ module ActiveCypher
           end
 
           target_class = target_class_name.constantize
-          a_alias = :a
-          b_alias = :b
+          start_alias = :start_node
+          target_alias = :target # Relation#map_results only unwraps the :n or :target alias
 
-          # plain node patterns (no mutating helpers)
-          a_node = Cyrel::Pattern::Node.new(a_alias, labels: self.class.label_name)
-          b_node = Cyrel::Pattern::Node.new(b_alias, labels: target_class.label_name)
-
-          # explicit relationship node – mirrors Arel::Nodes::Join construction
-          rel = Cyrel::Pattern::Relationship.new(
-            types: rel_type,
-            direction: Cyrel::Direction::BOTH # undirected ‹--›
+          # belongs_to matches the relationship undirected (‹--›), regardless of declared direction
+          path = Associations.relationship_path(
+            Associations.node_pattern(self.class, start_alias),
+            Associations.node_pattern(target_class, target_alias),
+            :both, rel_type
           )
-
-          path = Cyrel::Pattern::Path.new([a_node, rel, b_node])
 
           query = Cyrel::Query.new
                               .match(path)
-                              .where(Cyrel.node_id(a_alias).eq(internal_id))
-                              .return_(b_alias)
+                              .where(Cyrel.node_id(start_alias).eq(internal_id))
+                              .return_(target_alias)
                               .limit(1)
 
           relation = Relation.new(target_class, query)
@@ -197,93 +254,7 @@ module ActiveCypher
         end
 
         # Define writer (e.g., author=)
-        define_method("#{name}=") do |associate|
-          instance_var = "@#{name}"
-          # Load current associate lazily only if needed for comparison or deletion
-          current_associate = instance_variable_defined?(instance_var) ? instance_variable_get(instance_var) : nil
-          # Load if not cached and persisted
-          current_associate = public_send(name) if current_associate.nil? && persisted?
-
-          # No change if assigning the same object
-          return associate if associate == current_associate
-
-          raise 'Cannot modify associations on a new record' unless persisted?
-
-          # --- Delete existing relationship (if any) ---
-          if current_associate
-            del_start_alias = :a
-            del_end_alias   = :b
-            del_rel_alias   = :r
-            cyrel_direction = if direction == :in
-                                :out
-                              else
-                                (direction == :both ? :both : direction)
-                              end
-
-            del_query = Cyrel
-                        .match(Cyrel.node(del_start_node.class.label_name).as(del_start_alias))
-                        .match(Cyrel.node(del_end_node.class.label_name).as(del_end_alias))
-                        .match(Cyrel.node(del_start_alias)
-                                      .rel(cyrel_direction, rel_type)
-                                      .as(del_rel_alias)
-                                      .to(del_end_alias))
-                        .where(Cyrel.node_id(del_start_alias).eq(del_start_node.internal_id))
-                        .where(Cyrel.node_id(del_end_alias).eq(del_end_node.internal_id))
-                        .delete(del_rel_alias)
-
-            self.class.connection.execute_cypher(
-              *del_query.to_cypher,
-              'Delete Association (belongs_to)'
-            )
-          end
-
-          # --- Create new relationship (if associate is not nil) ---
-          if associate
-            raise ArgumentError, "Associated object must be an instance of #{target_class_name}" unless associate.is_a?(target_class_name.constantize)
-            raise "Associated object #{associate.inspect} must be persisted" unless associate.persisted?
-
-            # Determine start/end nodes for creation based on direction
-            new_start_node, new_end_node =
-              case direction
-              when :out then [self, associate]
-              when :in   then [associate, self]
-              when :both then [self, associate] # choose a deterministic orientation
-              else raise ArgumentError,
-                         "Direction '#{direction}' not supported for creation via '='"
-              end
-
-            if reflection[:relationship_class]
-              # Use Relationship Model
-              rel_model_class = reflection[:relationship_class].constantize
-              # TODO: Extract relationship properties if passed somehow (e.g., via options hash?)
-              rel_props = {}
-              relationship_instance = rel_model_class.new(rel_props, from_node: new_start_node, to_node: new_end_node)
-              relationship_instance.save # Relationship model handles Cypher generation
-            else
-              # Use direct Cypher generation
-              new_start_alias = :a
-              new_end_alias   = :b
-              arrow           = direction == :both ? :both : :out
-
-              create_query = Cyrel
-                             .match(Cyrel.node(new_start_node.class.label_name).as(new_start_alias))
-                             .match(Cyrel.node(new_end_node.class.label_name).as(new_end_alias))
-                             .where(Cyrel.node_id(new_start_alias).eq(new_start_node.internal_id))
-                             .where(Cyrel.node_id(new_end_alias).eq(new_end_node.internal_id))
-                             .create(Cyrel.node(new_start_alias)
-                                            .rel(arrow, rel_type)
-                                            .to(new_end_alias))
-
-              self.class.connection.execute_cypher(
-                *create_query.to_cypher,
-                'Create Association (belongs_to - Direct)'
-              )
-            end
-          end
-
-          # Update the instance variable cache
-          instance_variable_set(instance_var, associate)
-        end
+        define_singular_writer(name, target_class_name, rel_type, direction, reflection)
 
         define_build_and_create_methods(name, target_class_name)
       end
@@ -312,45 +283,12 @@ module ActiveCypher
         end
       end
 
-      def define_has_one_methods(reflection)
-        name = reflection[:name]
-        target_class_name = reflection[:class_name]
-        rel_type = reflection[:relationship]
-        direction = reflection[:direction] # :in, :out, :both
+      # Defines the writer (name=) for a singular association (has_one / belongs_to).
+      # Both macros build the same delete-then-create Cypher; only the log label,
+      # taken from reflection[:macro], differs.
+      def define_singular_writer(name, target_class_name, rel_type, direction, reflection)
+        macro = reflection[:macro]
 
-        # Define reader method (e.g., profile) - logic is same as belongs_to reader
-        define_method(name) do
-          instance_var = "@#{name}"
-          return instance_variable_get(instance_var) if instance_variable_defined?(instance_var)
-
-          raise ActiveCypher::PersistenceError, 'Association load attempted on unsaved record' unless persisted?
-
-          target_class = target_class_name.constantize
-          start_node_alias = :start_node
-          target_node_alias = :target_node
-
-          start_node_pattern = Cyrel.node(self.class.label_name).as(start_node_alias)
-                                    .where(Cyrel.node_id(start_node_alias).eq(internal_id))
-          target_node_pattern = Cyrel.node(target_class.label_name).as(target_node_alias)
-
-          rel_pattern = case direction
-                        when :out
-                          start_node_pattern.rel(:out, rel_type).to(target_node_pattern)
-                        when :in
-                          target_node_pattern.rel(:out, rel_type).to(start_node_pattern) # Reverse for Cyrel syntax
-                        when :both
-                          start_node_pattern.rel(:both, rel_type).to(target_node_pattern)
-                        else
-                          raise AssociationError, "Invalid direction: #{direction}"
-                        end
-
-          query = Cyrel.match(rel_pattern).return(target_node_alias).limit(1)
-
-          relation = Relation.new(target_class, query)
-          instance_variable_set(instance_var, relation.first)
-        end
-
-        # Define writer (e.g., profile=)
         define_method("#{name}=") do |associate|
           instance_var = "@#{name}"
           # Load current associate lazily only if needed for comparison or deletion
@@ -365,33 +303,15 @@ module ActiveCypher
 
           # --- Delete existing relationship (if any) ---
           if current_associate
-            # Determine start/end nodes for deletion based on direction
-            del_start_node, del_end_node = case direction
-                                           when :out then [self, current_associate]
-                                           when :in then [current_associate, self]
-                                           else raise ArgumentError,
-                                                      "Direction '#{direction}' not supported for deletion via '='"
-                                           end
-
-            # Build Cyrel query to delete the relationship
-            del_start_alias = :a
-            del_end_alias = :b
-            del_rel_alias = :r
-            # Adjust direction for Cyrel pattern if needed
-            cyrel_direction = direction == :in ? :out : direction
-            del_query = Cyrel.match(Cyrel.node(del_start_node.class.label_name)
-                                         .as(del_start_alias).where(Cyrel.node_id(del_start_alias)
-                                                                         .eq(del_start_node.internal_id)))
-                             .match(Cyrel.node(del_end_node.class.label_name)
-                                         .as(del_end_alias).where(Cyrel.node_id(del_end_alias)
-                                                                       .eq(del_end_node.internal_id)))
-                             .match(Cyrel.node(del_start_alias).rel(cyrel_direction,
-                                                                    rel_type).as(del_rel_alias).to(del_end_alias))
-                             .delete(del_rel_alias)
-
-            del_cypher = del_query.to_cypher
-            del_params = { start_id: del_start_node.internal_id, end_id: del_end_node.internal_id }
-            self.class.connection.execute_cypher(del_cypher, del_params, 'Delete Association (has_one)')
+            del_start_node, del_end_node = Associations.ordered_endpoints(self, current_associate, direction)
+            del_arrow = direction == :both ? :both : :out
+            del_query = Associations.match_endpoints(del_start_node, :a, del_end_node, :b)
+                                    .match(Associations.relationship_path(
+                                             Cyrel::Pattern::Node.new(:a), Cyrel::Pattern::Node.new(:b),
+                                             del_arrow, rel_type, rel_alias: :r
+                                           ))
+                                    .delete_(:r)
+            self.class.connection.execute_cypher(*del_query.to_cypher, "Delete Association (#{macro})")
           end
 
           # --- Create new relationship (if associate is not nil) ---
@@ -399,125 +319,123 @@ module ActiveCypher
             raise ArgumentError, "Associated object must be an instance of #{target_class_name}" unless associate.is_a?(target_class_name.constantize)
             raise "Associated object #{associate.inspect} must be persisted" unless associate.persisted?
 
-            # Determine start/end nodes for creation based on direction
-            new_start_node, new_end_node = case direction
-                                           when :out then [self, associate]
-                                           when :in then [associate, self]
-                                           else raise ArgumentError,
-                                                      "Direction '#{direction}' not supported for creation via '='"
-                                           end
+            new_start_node, new_end_node = Associations.ordered_endpoints(self, associate, direction)
 
             if reflection[:relationship_class]
               # Use Relationship Model
               rel_model_class = reflection[:relationship_class].constantize
-              # TODO: Extract relationship properties if passed somehow
-              rel_props = {}
-              relationship_instance = rel_model_class.new(rel_props, from_node: new_start_node, to_node: new_end_node)
-              relationship_instance.save
+              relationship_instance = rel_model_class.new({}, from_node: new_start_node, to_node: new_end_node)
+              relationship_instance.save # Relationship model handles Cypher generation
             else
               # Use direct Cypher generation
-              new_start_alias = :a
-              new_end_alias = :b
-              create_query = Cyrel.match(Cyrel.node(new_start_node.class.label_name)
-                                              .as(new_start_alias).where(Cyrel.node_id(new_start_alias)
-                                                                              .eq(new_start_node.internal_id)))
-                                  .match(Cyrel.node(new_end_node.class.label_name)
-                                              .as(new_end_alias).where(Cyrel.node_id(new_end_alias)
-                                                                            .eq(new_end_node.internal_id)))
-                                  .create(Cyrel.node(new_start_alias).rel(:out, rel_type).to(new_end_alias))
-
-              create_cypher = create_query.to_cypher
-              create_params = { start_id: new_start_node.internal_id, end_id: new_end_node.internal_id }
-              self.class.connection.execute_cypher(create_cypher, create_params,
-                                                   'Create Association (has_one - Direct)')
+              create_query = Associations.match_endpoints(new_start_node, :a, new_end_node, :b)
+                                         .create(Associations.relationship_path(
+                                                   Cyrel::Pattern::Node.new(:a), Cyrel::Pattern::Node.new(:b),
+                                                   :out, rel_type
+                                                 ))
+              self.class.connection.execute_cypher(*create_query.to_cypher, "Create Association (#{macro} - Direct)")
             end
           end
 
           # Update the instance variable cache
           instance_variable_set(instance_var, associate)
         end
+      end
+
+      def define_has_one_methods(reflection)
+        name = reflection[:name]
+        target_class_name = reflection[:class_name]
+        rel_type = reflection[:relationship]
+        direction = reflection[:direction] # :in, :out, :both
+
+        # Define reader method (e.g., profile) - logic is same as belongs_to reader
+        define_method(name) do
+          instance_var = "@#{name}"
+          return instance_variable_get(instance_var) if instance_variable_defined?(instance_var)
+
+          raise ActiveCypher::PersistenceError, 'Association load attempted on unsaved record' unless persisted?
+
+          target_class = target_class_name.constantize
+          start_alias = :start_node
+          target_alias = :target # Relation#map_results only unwraps the :n or :target alias
+
+          path = Associations.relationship_path(
+            Associations.node_pattern(self.class, start_alias),
+            Associations.node_pattern(target_class, target_alias),
+            direction, rel_type
+          )
+
+          query = Cyrel::Query.new
+                              .match(path)
+                              .where(Cyrel.node_id(start_alias).eq(internal_id))
+                              .return_(target_alias)
+                              .limit(1)
+
+          relation = Relation.new(target_class, query)
+          instance_variable_set(instance_var, relation.first)
+        end
+
+        # Define writer (e.g., profile=)
+        define_singular_writer(name, target_class_name, rel_type, direction, reflection)
 
         define_build_and_create_methods(name, target_class_name)
       end
-    end
 
-    # Defines the reader method for a has_many :through association.
-    # Because sometimes you want to join tables, but with extra steps.
-    def self.define_has_many_through_reader(reflection)
-      name = reflection[:name]
-      through_association_name = reflection[:through]
-      source_association_name = reflection[:source] || name # Default source is same name on intermediate model
+      # Defines the reader method for a has_many :through association.
+      # Because sometimes you want to join tables, but with extra steps.
+      def define_has_many_through_reader(reflection)
+        name = reflection[:name]
+        through_association_name = reflection[:through]
+        source_association_name = reflection[:source] || name # Default source is same name on intermediate model
 
-      define_method(name) do
-        raise ActiveCypher::PersistenceError, 'Association load attempted on unsaved record' unless persisted?
+        define_method(name) do
+          raise ActiveCypher::PersistenceError, 'Association load attempted on unsaved record' unless persisted?
 
-        # 1. Get reflection for the intermediate association (e.g., :friendships)
-        through_reflection = self.class._reflections[through_association_name]
-        unless through_reflection
-          raise ArgumentError,
-                "Could not find association '#{through_association_name}' specified in :through option for '#{name}'"
+          # 1. Get reflection for the intermediate association (e.g., :friendships)
+          through_reflection = self.class._reflections[through_association_name]
+          unless through_reflection
+            raise ArgumentError,
+                  "Could not find association '#{through_association_name}' specified in :through option for '#{name}'"
+          end
+
+          intermediate_class = through_reflection[:class_name].constantize
+
+          # 2. Get reflection for the source association on the intermediate model (e.g., :to_node on Friendship)
+          # Note: This assumes the intermediate model also uses ActiveCypher::Associations
+          source_reflection = intermediate_class._reflections[source_association_name]
+          unless source_reflection
+            raise ArgumentError,
+                  "Could not find association '#{source_association_name}' specified as :source (or inferred) on '#{intermediate_class.name}' for '#{name}'"
+          end
+
+          final_target_class = source_reflection[:class_name].constantize
+
+          # 3. Build the multi-hop Cyrel query.
+          # Because why settle for one hop when you can have two and still not get what you want?
+          start_alias = :start_node
+          intermediate_alias = :intermediate_node
+          final_target_alias = :target # Relation#map_results only unwraps the :n or :target alias
+
+          # The intermediate node pattern is shared by both hops so the aliases line up:
+          #   MATCH (start)-[:THROUGH]->(intermediate) MATCH (intermediate)-[:SOURCE]->(final)
+          start_node = Associations.node_pattern(self.class, start_alias)
+          intermediate_node = Associations.node_pattern(intermediate_class, intermediate_alias)
+          final_target_node = Associations.node_pattern(final_target_class, final_target_alias)
+
+          first_hop = Associations.relationship_path(start_node, intermediate_node,
+                                                     through_reflection[:direction], through_reflection[:relationship])
+          second_hop = Associations.relationship_path(intermediate_node, final_target_node,
+                                                      source_reflection[:direction], source_reflection[:relationship])
+
+          query = Cyrel::Query.new
+                              .match(first_hop)
+                              .match(second_hop)
+                              .where(Cyrel.node_id(start_alias).eq(internal_id))
+                              .return_(final_target_alias)
+
+          # Return a Relation scoped to the final target class
+          Relation.new(final_target_class, query)
         end
-
-        intermediate_class = through_reflection[:class_name].constantize
-
-        # 2. Get reflection for the source association on the intermediate model (e.g., :to_node on Friendship)
-        # Note: This assumes the intermediate model also uses ActiveCypher::Associations
-        source_reflection = intermediate_class._reflections[source_association_name]
-        unless source_reflection
-          raise ArgumentError,
-                "Could not find association '#{source_association_name}' specified as :source (or inferred) on '#{intermediate_class.name}' for '#{name}'"
-        end
-
-        final_target_class = source_reflection[:class_name].constantize
-
-        # 3. Build the multi-hop Cyrel query.
-        # Because why settle for one hop when you can have two and still not get what you want?
-        start_node_alias = :start_node
-        intermediate_node_alias = :intermediate_node
-        final_target_node_alias = :final_target
-
-        # Start node pattern
-        start_node_pattern = Cyrel.node(self.class.label_name).as(start_node_alias)
-                                  .where(Cyrel.node_id(start_node_alias).eq(internal_id))
-
-        # Intermediate node pattern (based on through_reflection)
-        intermediate_node_pattern = Cyrel.node(intermediate_class.label_name).as(intermediate_node_alias)
-        through_rel_type = through_reflection[:relationship]
-        through_direction = through_reflection[:direction]
-
-        first_hop_pattern = case through_direction
-                            when :out then start_node_pattern.rel(:out, through_rel_type).to(intermediate_node_pattern)
-                            when :in then intermediate_node_pattern.rel(:out, through_rel_type).to(start_node_pattern)
-                            when :both then start_node_pattern.rel(:both,
-                                                                   through_rel_type).to(intermediate_node_pattern)
-                            else raise ArgumentError, "Invalid direction in through_reflection: #{through_direction}"
-                            end
-
-        # Final target node pattern (based on source_reflection)
-        final_target_node_pattern = Cyrel.node(final_target_class.label_name).as(final_target_node_alias)
-        source_rel_type = source_reflection[:relationship]
-        source_direction = source_reflection[:direction]
-
-        second_hop_pattern = case source_direction
-                             when :out then intermediate_node_pattern.rel(:out,
-                                                                          source_rel_type).to(final_target_node_pattern)
-                             when :in then final_target_node_pattern.rel(:out,
-                                                                         source_rel_type).to(intermediate_node_pattern)
-                             when :both then intermediate_node_pattern.rel(:both,
-                                                                           source_rel_type).to(final_target_node_pattern)
-                             else raise ArgumentError, "Invalid direction in source_reflection: #{source_direction}"
-                             end
-
-        # Combine patterns and return final target
-        # Assuming Cyrel allows chaining matches or building complex patterns
-        # This might need adjustment based on Cyrel's exact path-building API
-        query = Cyrel.match(first_hop_pattern)
-                     .match(second_hop_pattern) # Assumes .match adds to the pattern
-                     .return(final_target_node_alias)
-        # TODO: Add DISTINCT if needed? .return(Cyrel.distinct(final_target_node_alias))
-
-        # Return a Relation scoped to the final target class
-        Relation.new(final_target_class, query)
       end
     end
   end

--- a/lib/active_cypher/bolt/connection.rb
+++ b/lib/active_cypher/bolt/connection.rb
@@ -638,55 +638,35 @@ module ActiveCypher
 
         case @server_agent
         when %r{^Neo4j/(\d+\.\d+(?:\.\d+)?)}i
-          version_string = ::Regexp.last_match(1)
-          parts = version_string.split('.').map(&:to_i)
-          {
-            database_type: :neo4j,
-            version: version_string,
-            major: parts[0] || 0,
-            minor: parts[1] || 0,
-            patch: parts[2] || 0
-          }
+          version_info_from(:neo4j, ::Regexp.last_match(1))
         when %r{^Memgraph/(\d+\.\d+(?:\.\d+)?)}i
-          version_string = ::Regexp.last_match(1)
-          parts = version_string.split('.').map(&:to_i)
-          {
-            database_type: :memgraph,
-            version: version_string,
-            major: parts[0] || 0,
-            minor: parts[1] || 0,
-            patch: parts[2] || 0
-          }
+          version_info_from(:memgraph, ::Regexp.last_match(1))
         when /.*Memgraph/i
           # Handle Memgraph server agent: "Neo4j/v5.11.0 compatible graph database server - Memgraph"
           if @server_agent =~ %r{Neo4j/v(\d+\.\d+(?:\.\d+)?)}
-            version_string = ::Regexp.last_match(1)
-            parts = version_string.split('.').map(&:to_i)
-            {
-              database_type: :memgraph,
-              version: version_string,
-              major: parts[0] || 0,
-              minor: parts[1] || 0,
-              patch: parts[2] || 0
-            }
+            version_info_from(:memgraph, ::Regexp.last_match(1))
           else
-            {
-              database_type: :memgraph,
-              version: 'unknown',
-              major: 0,
-              minor: 0,
-              patch: 0
-            }
+            { database_type: :memgraph, version: 'unknown', major: 0, minor: 0, patch: 0 }
           end
         else
-          {
-            database_type: :unknown,
-            version: @server_agent,
-            major: 0,
-            minor: 0,
-            patch: 0
-          }
+          { database_type: :unknown, version: @server_agent, major: 0, minor: 0, patch: 0 }
         end
+      end
+
+      # Builds a version info hash from a dotted version string.
+      #
+      # @param database_type [Symbol] :neo4j or :memgraph
+      # @param version_string [String] dotted version, e.g. "5.11.0"
+      # @return [Hash] version information
+      def version_info_from(database_type, version_string)
+        parts = version_string.split('.').map(&:to_i)
+        {
+          database_type: database_type,
+          version: version_string,
+          major: parts[0] || 0,
+          minor: parts[1] || 0,
+          patch: parts[2] || 0
+        }
       end
 
       # Returns default version info when server_agent is not available.

--- a/lib/active_cypher/connection_adapters/memgraph_adapter.rb
+++ b/lib/active_cypher/connection_adapters/memgraph_adapter.rb
@@ -159,10 +159,7 @@ module ActiveCypher
                 # End of results
                 break
               when Bolt::Messaging::Failure
-                code = msg.metadata['code']
-                message = msg.metadata['message']
-                connection.reset!
-                raise QueryError, "Query failed: #{code} - #{message}"
+                raise_query_failure(msg)
               else
                 raise ProtocolError, "Unexpected response during PULL: #{msg.class}"
               end
@@ -170,14 +167,19 @@ module ActiveCypher
 
             rows
           when Bolt::Messaging::Failure
-            code = run_response.metadata['code']
-            message = run_response.metadata['message']
-            connection.reset!
-            raise QueryError, "Query failed: #{code} - #{message}"
+            raise_query_failure(run_response)
           else
             raise ProtocolError, "Unexpected response to RUN: #{run_response.class}"
           end
         end
+      end
+
+      # Reset the connection and raise a QueryError for a Bolt Failure message.
+      # @param failure [Bolt::Messaging::Failure]
+      # @raise [QueryError]
+      def raise_query_failure(failure)
+        connection.reset!
+        raise QueryError, "Query failed: #{failure.metadata['code']} - #{failure.metadata['message']}"
       end
 
       # Memgraph defaults to **implicit auto‑commit** transactions
@@ -276,7 +278,7 @@ module ActiveCypher
       module Persistence
         include PersistenceMethods
 
-        module_function :create_record, :update_record, :destroy_record
+        module_function :create_record, :update_record, :destroy_record, :node_id_expr
       end
 
       class ProtocolHandler < AbstractProtocolHandler

--- a/lib/active_cypher/connection_adapters/neo4j_adapter.rb
+++ b/lib/active_cypher/connection_adapters/neo4j_adapter.rb
@@ -133,7 +133,7 @@ module ActiveCypher
       module Persistence
         include PersistenceMethods
 
-        module_function :create_record, :update_record, :destroy_record
+        module_function :create_record, :update_record, :destroy_record, :node_id_expr
       end
 
       protected

--- a/lib/active_cypher/connection_adapters/persistence_methods.rb
+++ b/lib/active_cypher/connection_adapters/persistence_methods.rb
@@ -20,11 +20,7 @@ module ActiveCypher
         # OPTIMIZED: Use string template instead of Cyrel for known-safe CREATE pattern
         # Labels come from model class (safe), props are parameterized (safe)
         label_string = labels.map { |l| ":#{l}" }.join
-        cypher = if adapter.id_function == 'elementId'
-                   "CREATE (n#{label_string} $props) RETURN elementId(n) AS internal_id"
-                 else
-                   "CREATE (n#{label_string} $props) RETURN id(n) AS internal_id"
-                 end
+        cypher = "CREATE (n#{label_string} $props) RETURN #{node_id_expr(adapter)} AS internal_id"
 
         data = model.connection.execute_cypher(cypher, { props: props }, 'Create')
 
@@ -59,11 +55,7 @@ module ActiveCypher
         label_string = labels.map { |l| ":#{l}" }.join
         set_clauses = changes.keys.map { |property| "n.#{property} = $#{property}" }.join(', ')
 
-        cypher = if adapter.id_function == 'elementId'
-                   "MATCH (n#{label_string}) WHERE elementId(n) = $node_id SET #{set_clauses} RETURN n"
-                 else
-                   "MATCH (n#{label_string}) WHERE id(n) = $node_id SET #{set_clauses} RETURN n"
-                 end
+        cypher = "MATCH (n#{label_string}) WHERE #{node_id_expr(adapter)} = $node_id SET #{set_clauses} RETURN n"
 
         params = changes.merge(node_id: node_id_param)
         model.connection.execute_cypher(cypher, params, 'Update')
@@ -91,14 +83,19 @@ module ActiveCypher
         # Labels come from model class (safe)
         label_string = labels.map { |l| ":#{l}" }.join
 
-        cypher = if adapter.id_function == 'elementId'
-                   "MATCH (n#{label_string}) WHERE elementId(n) = $node_id DETACH DELETE n RETURN count(*) AS deleted"
-                 else
-                   "MATCH (n#{label_string}) WHERE id(n) = $node_id DETACH DELETE n RETURN count(*) AS deleted"
-                 end
+        cypher = "MATCH (n#{label_string}) WHERE #{node_id_expr(adapter)} = $node_id DETACH DELETE n RETURN count(*) AS deleted"
 
         result = model.connection.execute_cypher(cypher, { node_id: node_id_param }, 'Destroy')
         result.present? && result.first[:deleted].to_i.positive?
+      end
+
+      private
+
+      # The node-id function call for the adapter's dialect (Neo4j uses elementId, Memgraph id).
+      # @param adapter [#id_function] the connection's id handler
+      # @return [String] "elementId(n)" or "id(n)"
+      def node_id_expr(adapter)
+        adapter.id_function == 'elementId' ? 'elementId(n)' : 'id(n)'
       end
     end
   end

--- a/lib/active_cypher/fixtures.rb
+++ b/lib/active_cypher/fixtures.rb
@@ -35,11 +35,7 @@ module ActiveCypher
       connections = model_classes.map(&:connection).compact.uniq
 
       # 6. Wipe all nodes in each relevant connection
-      connections.each do |conn|
-        conn.execute_cypher('MATCH (n) DETACH DELETE n')
-      rescue StandardError => e
-        warn "[ActiveCypher::Fixtures.load] Failed to clear connection #{conn.inspect}: #{e.class}: #{e.message}"
-      end
+      wipe_connections(connections, 'load')
 
       # 7. Evaluate nodes and relationships (batched if large)
       if dsl_context.nodes.size > 100 || dsl_context.relationships.size > 200
@@ -77,12 +73,39 @@ module ActiveCypher
       connections = model_classes.map(&:connection).compact.uniq
 
       # Wipe all nodes in each connection
+      wipe_connections(connections, 'clear_all')
+      true
+    end
+
+    # Build a comparable connection fingerprint for cross-database detection.
+    # @param conn [Object] a model connection
+    # @return [Hash] adapter/config/object_id details
+    def self.connection_details(conn)
+      {
+        adapter: conn.class.name,
+        config: conn.instance_variable_get(:@config),
+        object_id: conn.object_id
+      }
+    end
+
+    # Memoized connection-details lookup for a model class.
+    # @param klass [Class] the model class
+    # @param cache [Hash] class => details mapping, populated on miss
+    # @return [Hash] the connection details
+    def self.conn_details_for(klass, cache)
+      cache[klass] ||= connection_details(klass.connection)
+    end
+
+    # Detach-delete every node across the given connections, logging per-connection failures.
+    # @param connections [Array] connections to wipe
+    # @param context [String] caller name used in the warning prefix
+    # @return [void]
+    def self.wipe_connections(connections, context)
       connections.each do |conn|
         conn.execute_cypher('MATCH (n) DETACH DELETE n')
       rescue StandardError => e
-        warn "[ActiveCypher::Fixtures.clear_all] Failed to clear connection #{conn.inspect}: #{e.class}: #{e.message}"
+        warn "[ActiveCypher::Fixtures.#{context}] Failed to clear connection #{conn.inspect}: #{e.class}: #{e.message}"
       end
-      true
     end
 
     # Validates relationships for cross-DB issues
@@ -96,13 +119,8 @@ module ActiveCypher
         next unless klass < ActiveCypher::Base
         next if klass.respond_to?(:abstract_class?) && klass.abstract_class?
 
-        conn = klass.connection
         # Store connection details for comparison
-        model_connections[klass] = {
-          adapter: conn.class.name,
-          config: conn.instance_variable_get(:@config),
-          object_id: conn.object_id
-        }
+        model_connections[klass] = connection_details(klass.connection)
       end
 
       relationships.each do |rel|
@@ -120,30 +138,9 @@ module ActiveCypher
         from_class = from_node.class
         to_class = to_node.class
 
-        # Look up connection details for each class
-        from_conn_details = model_connections[from_class]
-        to_conn_details = model_connections[to_class]
-
-        # If either class isn't in our mapping, refresh it
-        unless from_conn_details
-          conn = from_class.connection
-          from_conn_details = {
-            adapter: conn.class.name,
-            config: conn.instance_variable_get(:@config),
-            object_id: conn.object_id
-          }
-          model_connections[from_class] = from_conn_details
-        end
-
-        unless to_conn_details
-          conn = to_class.connection
-          to_conn_details = {
-            adapter: conn.class.name,
-            config: conn.instance_variable_get(:@config),
-            object_id: conn.object_id
-          }
-          model_connections[to_class] = to_conn_details
-        end
+        # Look up connection details for each class, refreshing the cache on miss
+        from_conn_details = conn_details_for(from_class, model_connections)
+        to_conn_details = conn_details_for(to_class, model_connections)
 
         # Compare connection details
         next unless from_conn_details[:object_id] != to_conn_details[:object_id] ||

--- a/lib/active_cypher/migration.rb
+++ b/lib/active_cypher/migration.rb
@@ -40,14 +40,7 @@ module ActiveCypher
       composite = props.size > 1 if composite.nil?
 
       cypher = if connection.vendor == :memgraph
-                 if composite && props.size > 1
-                   # Memgraph 3.2+ composite index: CREATE INDEX ON :Label(prop1, prop2)
-                   props_list = props.join(', ')
-                   ["CREATE INDEX ON :#{label}(#{props_list})"]
-                 else
-                   # Memgraph single property indexes
-                   props.map { |p| "CREATE INDEX ON :#{label}(#{p})" }
-                 end
+                 memgraph_index_statements('INDEX', label, props, composite)
                else
                  # Neo4j syntax
                  props_clause = props.map { |p| "n.#{p}" }.join(', ')
@@ -72,13 +65,7 @@ module ActiveCypher
       composite = props.size > 1 if composite.nil?
 
       cypher = if connection.vendor == :memgraph
-                 if composite && props.size > 1
-                   # Memgraph 3.2+ composite edge index
-                   props_list = props.join(', ')
-                   ["CREATE EDGE INDEX ON :#{rel_type}(#{props_list})"]
-                 else
-                   props.map { |p| "CREATE EDGE INDEX ON :#{rel_type}(#{p})" }
-                 end
+                 memgraph_index_statements('EDGE INDEX', rel_type, props, composite)
                else
                  # Neo4j syntax
                  props_clause = props.map { |p| "r.#{p}" }.join(', ')
@@ -220,6 +207,22 @@ module ActiveCypher
     end
 
     private
+
+    # Build Memgraph CREATE [EDGE] INDEX statements for a label/type and properties.
+    # @param index_keyword [String] "INDEX" for nodes, "EDGE INDEX" for relationships
+    # @param label [Symbol, String] node label or relationship type
+    # @param props [Array<Symbol, String>] properties to index
+    # @param composite [Boolean] emit a single composite index when more than one prop
+    # @return [Array<String>] one or more Cypher statements
+    def memgraph_index_statements(index_keyword, label, props, composite)
+      if composite && props.size > 1
+        # Memgraph 3.2+ composite index: CREATE [EDGE] INDEX ON :Label(prop1, prop2)
+        ["CREATE #{index_keyword} ON :#{label}(#{props.join(', ')})"]
+      else
+        # Single property indexes
+        props.map { |p| "CREATE #{index_keyword} ON :#{label}(#{p})" }
+      end
+    end
 
     def execute_operations
       if connection.vendor == :memgraph

--- a/lib/active_cypher/rails_lens_ext/annotator.rb
+++ b/lib/active_cypher/rails_lens_ext/annotator.rb
@@ -115,24 +115,10 @@ module ActiveCypher
           models = []
 
           # Find all Node classes (ActiveCypher::Base descendants)
-          if defined?(::ActiveCypher::Base)
-            ObjectSpace.each_object(Class) do |klass|
-              next unless klass < ::ActiveCypher::Base
-              next if klass == ::ActiveCypher::Base
-
-              models << klass
-            end
-          end
+          models.concat(descendants_of(::ActiveCypher::Base)) if defined?(::ActiveCypher::Base)
 
           # Find all Relationship classes (ActiveCypher::Relationship descendants)
-          if defined?(::ActiveCypher::Relationship)
-            ObjectSpace.each_object(Class) do |klass|
-              next unless klass < ::ActiveCypher::Relationship
-              next if klass == ::ActiveCypher::Relationship
-
-              models << klass
-            end
-          end
+          models.concat(descendants_of(::ActiveCypher::Relationship)) if defined?(::ActiveCypher::Relationship)
 
           # Filter out abstract classes unless requested
           models.reject! { |m| m.respond_to?(:abstract_class?) && m.abstract_class? } unless options[:include_abstract]
@@ -150,6 +136,19 @@ module ActiveCypher
           end
 
           models.sort_by { |m| m.name || '' }
+        end
+
+        # Collect every loaded subclass of +base+ (excluding +base+ itself).
+        # @param base [Class] the ancestor to scan for
+        # @return [Array<Class>] strict descendants of +base+
+        def descendants_of(base)
+          [].tap do |found|
+            ObjectSpace.each_object(Class) do |klass|
+              next unless klass < base
+
+              found << klass
+            end
+          end
         end
 
         # Eager load graph models from Rails app

--- a/lib/cyrel/ast/compiler.rb
+++ b/lib/cyrel/ast/compiler.rb
@@ -84,10 +84,7 @@ module Cyrel
         @output << 'RETURN '
         @output << 'DISTINCT ' if node.distinct
 
-        node.items.each_with_index do |item, index|
-          @output << ', ' if index.positive?
-          render_expression(item)
-        end
+        render_comma_separated(node.items)
       end
 
       # Visit a SET node
@@ -109,10 +106,7 @@ module Cyrel
         @output << 'WITH '
         @output << 'DISTINCT ' if node.distinct
 
-        node.items.each_with_index do |item, index|
-          @output << ', ' if index.positive?
-          render_expression(item)
-        end
+        render_comma_separated(node.items)
 
         # Add WHERE clause if present
         return unless node.where_conditions && !node.where_conditions.empty?
@@ -139,13 +133,8 @@ module Cyrel
         if node.expression.is_a?(Array)
           # Array literal
           @output << format_array_literal(node.expression)
-        elsif node.expression.is_a?(Symbol)
-          # Parameter reference
-          param_key = register_parameter(node.expression)
-          @output << "$#{param_key}"
         else
-          # Other expressions
-          render_expression(node.expression)
+          render_param_or_expression(node.expression)
         end
 
         @output << " AS #{node.alias_name}"
@@ -280,11 +269,11 @@ module Cyrel
 
             subquery_compiler = QueryIntegratedCompiler.new(parameter_proxy)
             clause_cypher, = subquery_compiler.compile(clause.ast_node)
-            @output << clause_cypher.split("\n").map { |line| "  #{line}" }.join("\n")
+            @output << indent_block(clause_cypher)
           else
             # For legacy clauses, render normally
             clause_output = clause.render(subquery)
-            @output << clause_output.split("\n").map { |line| "  #{line}" }.join("\n") unless clause_output.blank?
+            @output << indent_block(clause_output) unless clause_output.blank?
 
             # Merge subquery parameters
             subquery.parameters.each_value do |value|
@@ -346,18 +335,12 @@ module Cyrel
       def visit_foreach_node(node)
         @output << "FOREACH (#{node.variable} IN "
 
-        # Handle the expression - could be an array literal or an expression
+        # Handle the expression - could be an array literal or an expression.
+        # An array is parameterized whole; everything else defers to the shared helper.
         if node.expression.is_a?(Array)
-          # Array literal - convert to parameter
-          param_key = register_parameter(node.expression)
-          @output << "$#{param_key}"
-        elsif node.expression.is_a?(Symbol)
-          # Symbol reference to parameter
-          param_key = register_parameter(node.expression)
-          @output << "$#{param_key}"
+          @output << "$#{register_parameter(node.expression)}"
         else
-          # Other expressions
-          render_expression(node.expression)
+          render_param_or_expression(node.expression)
         end
 
         @output << ' | '
@@ -392,8 +375,6 @@ module Cyrel
           inner_compiler.instance_variable_set(:@loop_variables, @loop_variables.dup)
           clause_cypher, = inner_compiler.compile([clause.ast_node])
           @output << clause_cypher
-
-          # For other clause types, render directly
         end
 
         # Restore previous loop variables context
@@ -515,6 +496,34 @@ module Cyrel
           render_expression(Expression.coerce(value))
         else
           raise "Unknown SET item type: #{item.class}"
+        end
+      end
+
+      # Render a list of items separated by commas (RETURN/WITH projections).
+      # @param items [Array] the expressions to render
+      # @return [void]
+      def render_comma_separated(items)
+        items.each_with_index do |item, index|
+          @output << ', ' if index.positive?
+          render_expression(item)
+        end
+      end
+
+      # Indent every line of a Cypher fragment by two spaces (subquery nesting).
+      # @param text [String] the fragment to indent
+      # @return [String] the indented fragment
+      def indent_block(text)
+        text.split("\n").map { |line| "  #{line}" }.join("\n")
+      end
+
+      # Render a symbol as a parameter reference, otherwise delegate to {#render_expression}.
+      # @param expression [Object] the value to render
+      # @return [void]
+      def render_param_or_expression(expression)
+        if expression.is_a?(Symbol)
+          @output << "$#{register_parameter(expression)}"
+        else
+          render_expression(expression)
         end
       end
 

--- a/lib/cyrel/clause/set.rb
+++ b/lib/cyrel/clause/set.rb
@@ -17,7 +17,48 @@ module Cyrel
       #     e.g., [[:n, "NewLabel"], [:m, "AnotherLabel"]]
       #   Note: Mixing hash and array styles in one call is not directly supported, use multiple SET clauses if needed.
       def initialize(assignments)
-        @assignments = process_assignments(assignments)
+        @assignments = self.class.normalize_assignments(assignments)
+      end
+
+      # Normalize raw SET assignments (Hash of props/labels or Array of label pairs)
+      # into the internal tuple form consumed by both Clause::Set and Query#set.
+      # @param assignments [Hash, Array]
+      # @return [Array<Array>] tuples like [:property, ...], [:variable_properties, ...], [:label, ...]
+      def self.normalize_assignments(assignments)
+        case assignments
+        when Hash
+          assignments.flat_map do |key, value|
+            case key
+            when Expression::PropertyAccess
+              # SET n.prop = value
+              [[:property, key, Expression.coerce(value)]]
+            when Symbol, String
+              # SET n = properties
+              raise ArgumentError, 'Value for variable assignment must be a Hash (for SET n = {props})' unless value.is_a?(Hash)
+
+              [[:variable_properties, key.to_sym, Expression.coerce(value), :assign]]
+            when Cyrel::Plus
+              # SET n += properties
+              raise ArgumentError, 'Value for variable assignment must be a Hash (for SET n += {props})' unless value.is_a?(Hash)
+
+              [[:variable_properties, key.variable.to_sym, Expression.coerce(value), :merge]]
+            else
+              raise ArgumentError, "Invalid key type in SET assignments hash: #{key.class}"
+            end
+          end
+        when Array
+          assignments.map do |item|
+            unless item.is_a?(Array) && item.length == 2
+              raise ArgumentError,
+                    "Invalid label assignment format. Expected [[:variable, 'Label'], ...], got #{item.inspect}"
+            end
+
+            # SET n:Label
+            [:label, item[0].to_sym, item[1]]
+          end
+        else
+          raise ArgumentError, "Invalid assignments type for SET clause: #{assignments.class}"
+        end
       end
 
       # Renders the SET clause.
@@ -43,43 +84,6 @@ module Cyrel
       end
 
       private
-
-      def process_assignments(assignments)
-        case assignments
-        when Hash
-          assignments.flat_map do |key, value|
-            case key
-            when Expression::PropertyAccess
-              # SET n.prop = value
-              [[:property, key, Expression.coerce(value)]]
-            when Symbol, String
-              # SET n = properties
-              raise ArgumentError, 'Value for variable assignment must be a Hash (for SET n = {props})' unless value.is_a?(Hash)
-
-              [[:variable_properties, key.to_sym, Expression.coerce(value), :assign]]
-            when Cyrel::Plus
-              # SET n += properties
-              raise ArgumentError, 'Value for variable assignment must be a Hash (for SET n += {props})' unless value.is_a?(Hash)
-
-              [[:variable_properties, key.variable.to_sym, Expression.coerce(value), :merge]]
-            else
-              raise ArgumentError, "Invalid key type in SET assignments hash: #{key.class}"
-            end
-          end
-        when Array
-          assignments.map do |item|
-            unless item.is_a?(Array) && item.length == 2 && item[0].is_a?(Symbol) && item[1].is_a?(String)
-              raise ArgumentError,
-                    "Invalid label assignment format. Expected [[:variable, 'Label'], ...], got #{item.inspect}"
-            end
-
-            # SET n:Label
-            [:label, item[0], item[1]]
-          end
-        else
-          raise ArgumentError, "Invalid assignments type for SET clause: #{assignments.class}"
-        end
-      end
 
       def render_assignment(assignment, query)
         type, target, value, op = assignment

--- a/lib/cyrel/query.rb
+++ b/lib/cyrel/query.rb
@@ -213,40 +213,8 @@ module Cyrel
     # @return [self]
     # Because sometimes you just want to change everything and pretend it was always that way.
     def set(assignments)
-      # Process assignments similar to existing Set clause
-      processed_assignments = case assignments
-                              when Hash
-                                assignments.flat_map do |key, value|
-                                  case key
-                                  when Expression::PropertyAccess
-                                    # SET n.prop = value
-                                    [[:property, key, Expression.coerce(value)]]
-                                  when Symbol, String
-                                    # SET n = properties
-                                    raise ArgumentError, 'Value for variable assignment must be a Hash' unless value.is_a?(Hash)
-
-                                    [[:variable_properties, key.to_sym, Expression.coerce(value), :assign]]
-                                  when Cyrel::Plus
-                                    # SET n += properties
-                                    raise ArgumentError, 'Value for variable assignment must be a Hash' unless value.is_a?(Hash)
-
-                                    [[:variable_properties, key.variable.to_sym, Expression.coerce(value), :merge]]
-                                  else
-                                    raise ArgumentError, "Invalid key type in SET assignments: #{key.class}"
-                                  end
-                                end
-                              when Array
-                                assignments.map do |item|
-                                  unless item.is_a?(Array) && item.length == 2
-                                    raise ArgumentError, "Invalid label assignment format. Expected [[:variable, 'Label'], ...], got #{item.inspect}"
-                                  end
-
-                                  # SET n:Label
-                                  [:label, item[0].to_sym, item[1]]
-                                end
-                              else
-                                raise ArgumentError, "Invalid assignments type: #{assignments.class}"
-                              end
+      # Normalize assignments using the shared Set-clause logic
+      processed_assignments = Clause::Set.normalize_assignments(assignments)
 
       set_node = AST::SetNode.new(processed_assignments)
       ast_clause = AST::ClauseAdapter.new(set_node)

--- a/test/dummy/app/graph/city_node.rb
+++ b/test/dummy/app/graph/city_node.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# <rails-lens:graph:begin>
+# model_type = "node"
+# labels = ["City"]
+#
+# attributes = [{ name = "name", type = "string" }]
+#
+# [connection]
+# writing = "primary"
+# reading = "primary"
+# <rails-lens:graph:end>
+class CityNode < ApplicationGraphNode
+
+  attribute :name, :string
+end

--- a/test/dummy/app/graph/gadget_node.rb
+++ b/test/dummy/app/graph/gadget_node.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# <rails-lens:graph:begin>
+# model_type = "node"
+# labels = ["Gadget"]
+#
+# attributes = [{ name = "name", type = "string" }]
+#
+# [associations]
+# widget = { macro = "belongs_to", class = "WidgetNode", rel = "HAS_GADGET", direction = "in" }
+#
+# [connection]
+# writing = "primary"
+# reading = "primary"
+# <rails-lens:graph:end>
+class GadgetNode < ApplicationGraphNode
+
+  attribute :name, :string
+
+  belongs_to :widget,
+             class_name: 'WidgetNode',
+             relationship: 'HAS_GADGET',
+             direction: :in
+end

--- a/test/dummy/app/graph/road_node.rb
+++ b/test/dummy/app/graph/road_node.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# <rails-lens:graph:begin>
+# model_type = "node"
+# labels = ["Road"]
+#
+# attributes = [{ name = "name", type = "string" }]
+#
+# [associations]
+# city = { macro = "has_one", class = "CityNode", rel = "LEADS_TO" }
+#
+# [connection]
+# writing = "primary"
+# reading = "primary"
+# <rails-lens:graph:end>
+class RoadNode < ApplicationGraphNode
+
+  attribute :name, :string
+
+  has_one :city,
+          class_name: 'CityNode',
+          relationship: 'LEADS_TO',
+          direction: :out
+end

--- a/test/dummy/app/graph/town_node.rb
+++ b/test/dummy/app/graph/town_node.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# <rails-lens:graph:begin>
+# model_type = "node"
+# labels = ["Town"]
+#
+# attributes = [{ name = "name", type = "string" }]
+#
+# [associations]
+# roads = { macro = "has_many", class = "RoadNode", rel = "BUILT" }
+# cities = { macro = "has_many", class = "Cities", rel = "CITIES", through = "roads", source = "city" }
+#
+# [connection]
+# writing = "primary"
+# reading = "primary"
+# <rails-lens:graph:end>
+class TownNode < ApplicationGraphNode
+
+  attribute :name, :string
+
+  has_many :roads,
+           class_name: 'RoadNode',
+           relationship: 'BUILT',
+           direction: :out
+
+  has_many :cities, through: :roads, source: :city
+end

--- a/test/dummy/app/graph/widget_node.rb
+++ b/test/dummy/app/graph/widget_node.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# <rails-lens:graph:begin>
+# model_type = "node"
+# labels = ["Widget"]
+#
+# attributes = [{ name = "name", type = "string" }]
+#
+# [associations]
+# gadget = { macro = "has_one", class = "GadgetNode", rel = "HAS_GADGET" }
+# supplier = { macro = "has_one", class = "GadgetNode", rel = "SUPPLIES", direction = "in" }
+#
+# [connection]
+# writing = "primary"
+# reading = "primary"
+# <rails-lens:graph:end>
+class WidgetNode < ApplicationGraphNode
+
+  attribute :name, :string
+
+  has_one :gadget,
+          class_name: 'GadgetNode',
+          relationship: 'HAS_GADGET',
+          direction: :out
+
+  # Incoming direction: (gadget)-[:SUPPLIES]->(widget)
+  has_one :supplier,
+          class_name: 'GadgetNode',
+          relationship: 'SUPPLIES',
+          direction: :in
+end

--- a/test/relationships/singular_and_through_associations_test.rb
+++ b/test/relationships/singular_and_through_associations_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# End-to-end coverage for the singular (has_one / belongs_to writer) and
+# has_many :through association query paths. These were previously dead code
+# (they called fluent methods that do not exist on Cyrel::Pattern::Node) and
+# had no tests. Exercises the real dummy-app models against the live database.
+class SingularAndThroughAssociationsTest < ActiveSupport::TestCase
+  setup do
+    WidgetNode.connection.execute_cypher('MATCH (n) DETACH DELETE n')
+  end
+
+  test 'has_one writer creates an outgoing relationship, reader reads it, nil deletes it' do
+    widget = WidgetNode.create(name: 'W')
+    gadget = GadgetNode.create(name: 'G')
+
+    widget.gadget = gadget
+    assert_equal 1, rel_count('HAS_GADGET', widget, gadget)
+
+    reloaded = WidgetNode.find(widget.internal_id)
+    assert_equal gadget.internal_id, reloaded.gadget&.internal_id, 'reader should follow :out relationship'
+
+    widget.gadget = nil
+    assert_equal 0, rel_count('HAS_GADGET', widget, gadget), 'assigning nil should delete the relationship'
+  end
+
+  test 'has_one reader follows an incoming relationship for direction :in' do
+    widget = WidgetNode.create(name: 'W3')
+    supplier = GadgetNode.create(name: 'S')
+
+    # direction :in means (supplier)-[:SUPPLIES]->(widget)
+    create_rel('SUPPLIES', supplier, widget)
+
+    reloaded = WidgetNode.find(widget.internal_id)
+    assert_equal supplier.internal_id, reloaded.supplier&.internal_id
+  end
+
+  test 'belongs_to writer creates the relationship in the owner direction' do
+    widget = WidgetNode.create(name: 'W2')
+    gadget = GadgetNode.create(name: 'G2')
+
+    # GadgetNode belongs_to :widget with direction :in => (widget)-[:HAS_GADGET]->(gadget)
+    gadget.widget = widget
+    assert_equal 1, rel_count('HAS_GADGET', widget, gadget)
+
+    reloaded = GadgetNode.find(gadget.internal_id)
+    assert_equal widget.internal_id, reloaded.widget&.internal_id, 'belongs_to reader should find the owner'
+  end
+
+  test 'has_many :through traverses two hops' do
+    town = TownNode.create(name: 'Springfield')
+    road = RoadNode.create(name: 'Route 66')
+    city = CityNode.create(name: 'Capital')
+
+    create_rel('BUILT', town, road)
+    create_rel('LEADS_TO', road, city)
+
+    found = town.cities.to_a
+    assert_equal [city.internal_id], found.map(&:internal_id)
+  end
+
+  private
+
+  def adapter = WidgetNode.connection.id_handler
+
+  # NOTE: adapter.with_direct_node_ids hardcodes the aliases p (start) and h (end).
+  def rel_count(type, from_node, to_node)
+    WidgetNode.connection.execute_cypher(
+      "MATCH (p)-[r:#{type}]->(h)
+       WHERE #{adapter.with_direct_node_ids(from_node.internal_id, to_node.internal_id)}
+       RETURN COUNT(r) AS count"
+    )[0][:count]
+  end
+
+  def create_rel(type, from_node, to_node)
+    WidgetNode.connection.execute_cypher(
+      "MATCH (p), (h)
+       WHERE #{adapter.with_direct_node_ids(from_node.internal_id, to_node.internal_id)}
+       CREATE (p)-[:#{type}]->(h)"
+    )
+  end
+end


### PR DESCRIPTION
Associations called phantom .where/.rel/.to on Pattern::Node and never worked. Rewrite on the real Pattern/Query API, fix :through declaration, add coverage. Extract shared helpers across cyrel + adapters.

ping @metkat  

Can you review test this on your end.  I moved files around to remove the logic/helper duplication.