### PR TITLE
chore: re-annotate dummy graph models with rails_lens 0.5.4

### DIFF
--- a/test/dummy/app/graph/callback_person.rb
+++ b/test/dummy/app/graph/callback_person.rb
@@ -6,6 +6,9 @@
 #
 # attributes = [{ name = "id", type = "string" }, { name = "name", type = "string" }, { name = "age", type = "integer" }, { name = "active", type = "boolean" }, { name = "flag", type = "string" }]
 #
+# [associations]
+# hobbies = { macro = "has_many", class = "HobbyNode", rel = "ENJOYS", relationship_class = "EnjoysRel" }
+#
 # [connection]
 # writing = "primary"
 # reading = "primary"

--- a/test/dummy/app/graph/called_for_rel.rb
+++ b/test/dummy/app/graph/called_for_rel.rb
@@ -5,7 +5,6 @@
 # type = "CALLED_FOR"
 # from_class = "CallLogNode"
 # to_class = "CompanyNode"
-#
 # <rails-lens:graph:end>
 class CalledForRel < ApplicationGraphRelationship
 

--- a/test/dummy/app/graph/company_node.rb
+++ b/test/dummy/app/graph/company_node.rb
@@ -6,6 +6,9 @@
 #
 # attributes = [{ name = "id", type = "string" }, { name = "name", type = "string" }, { name = "founding_year", type = "integer" }, { name = "active", type = "boolean" }]
 #
+# [associations]
+# call_logs = { macro = "has_many", class = "CallLogNode", rel = "CALLED_FOR", direction = "in", relationship_class = "CalledForRel" }
+#
 # [connection]
 # writing = "neo4j"
 # reading = "neo4j"

--- a/test/dummy/app/graph/person_node.rb
+++ b/test/dummy/app/graph/person_node.rb
@@ -6,6 +6,9 @@
 #
 # attributes = [{ name = "id", type = "string" }, { name = "name", type = "string" }, { name = "age", type = "integer" }, { name = "active", type = "boolean" }]
 #
+# [associations]
+# hobbies = { macro = "has_many", class = "HobbyNode", rel = "ENJOYS", relationship_class = "EnjoysRel" }
+#
 # [connection]
 # writing = "primary"
 # reading = "primary"


### PR DESCRIPTION
Refreshes stale [associations] sections now that 0.5.4 no longer stacks duplicate annotation blocks on re-run.